### PR TITLE
Allow using server name in join and leave messages

### DIFF
--- a/src/main/java/me/feusalamander/vmessage/Listeners.java
+++ b/src/main/java/me/feusalamander/vmessage/Listeners.java
@@ -53,11 +53,13 @@ public final class Listeners {
             return;
         }
         Player p = e.getPlayer();
-        if (p.getCurrentServer().isEmpty()) {
+        Optional<ServerConnection> server = p.getCurrentServer();
+        if (server.isEmpty()) {
             return;
         }
         String message = configuration.getLeaveFormat()
-                .replace("#player#", p.getUsername());
+                .replace("#player#", p.getUsername())
+                .replace("#oldserver#", server.get().getServerInfo().getName());
         if (luckPermsAPI != null) {
             message = luckperms(message, p);
         }
@@ -98,7 +100,9 @@ public final class Listeners {
             if (!configuration.isJoinEnabled()) {
                 return;
             }
-            String message = configuration.getJoinFormat().replace("#player#", p.getUsername());
+            String message = configuration.getJoinFormat()
+                    .replace("#player#", p.getUsername())
+                    .replace("#server#", actual.getServerInfo().getName());
             if (luckPermsAPI != null) {
                 message = luckperms(message, p);
             }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -14,16 +14,18 @@ enabled = true
 [Join]
 #place holders:
 #- "#player#" : return the player name
+#- "#server#" : return the new player's server name
 #- "#prefix#" : return the player's luckperms prefix
 #- "#suffix#" : return the player's luckperms suffix
-format = "&7#prefix# #player# &ejoined the network"
+format = "&7#prefix# #player# &ejoined &7#server#"
 enabled = true
 [Leave]
 #place holders:
 #- "#player#" : return the player name
+#- "#oldserver#" : return the previous player's server name
 #- "#prefix#" : return the player's luckperms prefix
 #- "#suffix#" : return the player's luckperms suffix
-format = "#&7prefix# #player# &eleft the network"
+format = "#&7prefix# #player# &eleft &7#oldserver#"
 enabled = true
 [Server-change]
 #place holders:


### PR DESCRIPTION
This PR allows using the name of the server being connected to in the message sent when a player first joins the network, as well as the server being disconnected from in that when a player leaves the network.

For example:
```
PLAYER joined the network
```
can become
```
PLAYER joined vanilla
```
(assuming "PLAYER" is the username of the player, and "vanilla" is the name of the server being joined)

Similarly, "PLAYER left the network" can become "PLAYER left vanilla".

(please ignore the fact that i force-pushed my branch five times over :,) )